### PR TITLE
Allow specification of a custom user to run the server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,15 @@ MAINTAINER chris@cbrgm.de
 # Install dependencies
 RUN dpkg --add-architecture i386 && apt-get update && apt-get install -q -y wget lib32gcc1 telnet
 
+# Create group and user for the server
+ARG UID=999
+ARG GID=999
+RUN groupadd -g $GID steam && \
+    useradd -m -u $UID -g steam steam
+
 # Create workspace for server
 WORKDIR /home/steam
+USER steam
 
 # Downloading Steam cmd
 RUN wget http://media.steampowered.com/installer/steamcmd_linux.tar.gz
@@ -13,6 +20,7 @@ RUN mkdir ./bin && tar -zxf steamcmd_linux.tar.gz -C ./bin
 
 # Downloading 7Days Server
 RUN mkdir -p /home/steam/server
+WORKDIR /home/steam/server
 RUN /home/steam/bin/steamcmd.sh \
 	+login anonymous \
 	+force_install_dir /home/steam/server \
@@ -20,9 +28,9 @@ RUN /home/steam/bin/steamcmd.sh \
 	+quit
 
 # Copy serverconfig into dockercontainer
-RUN mkdir -p /root/.local/share/7DaysToDie/Saves
-COPY serverconfig.xml ./server
-COPY serveradmin.xml /root/.local/share/7DaysToDie/Saves/
+RUN mkdir -p /home/steam/.local/share/7DaysToDie/Saves
+COPY --chown=steam serverconfig.xml /home/steam/server/serverconfig.xml
+COPY --chown=steam serveradmin.xml /home/steam/.local/share/7DaysToDie/Saves/
 
 EXPOSE 8080/tcp 8081/tcp
 EXPOSE 26900-26902 26900-26902/udp


### PR DESCRIPTION
Running servers as root can pose security risks since no privilege escalation is needed if attackers can compromise the container and exit it.

These changes create a `steam` user with a UID/GID defaulting to `999` (but configurable with build args) and run the server as that user. They could also default to `0`, the root ID, if backwards compatibility is required.